### PR TITLE
権限の調整

### DIFF
--- a/auth/docker-compose.yml
+++ b/auth/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - openldap
       - phpldapadmin
     environment:
-      LDAP_IDENTITY: "cn=RadiusAdmin,dc=local,dc=doornoc,dc=net"
+      LDAP_IDENTITY: "cn=RadiusAdmin,ou=Services,dc=local,dc=doornoc,dc=net"
       LDAP_MANAGER_PASSWORD: "password"
       LDAP_BASE_DN: "dc=local,dc=doornoc,dc=net"
     ports:

--- a/auth/freeradius/root/etc/raddb/clients.conf
+++ b/auth/freeradius/root/etc/raddb/clients.conf
@@ -1,4 +1,4 @@
 client management {
-  ipaddr = 10.100.0.0/16
+  ipaddr = 10.0.0.0/8
   secret = keshikaran
 }

--- a/auth/freeradius/root/etc/raddb/users
+++ b/auth/freeradius/root/etc/raddb/users
@@ -1,2 +1,3 @@
 DEFAULT		Auth-Type = LDAP
+		Service-Type = Administrative,
 		Fall-Through = Yes

--- a/auth/freeradius/root/etc/raddb/users
+++ b/auth/freeradius/root/etc/raddb/users
@@ -1,3 +1,3 @@
 DEFAULT		Auth-Type = LDAP
-		Service-Type = Administrative,
+		Service-Type = Administrative
 		Fall-Through = Yes

--- a/auth/openldap/config/ldif/access.ldif
+++ b/auth/openldap/config/ldif/access.ldif
@@ -4,6 +4,7 @@ add: olcAccess
 olcAccess: to attrs=userPassword
   by anonymous auth
   by dn="cn=Admin,dc=my-domain,dc=com" read
+  by self =rwcsx
   by * none
 olcAccess: to *
   by self =rwcsx

--- a/auth/openldap/config/ldif/radiusAdmin-access.ldif
+++ b/auth/openldap/config/ldif/radiusAdmin-access.ldif
@@ -4,10 +4,10 @@ replace: olcAccess
 olcAccess: to attrs=userPassword
   by anonymous auth 
   by dn="cn=Admin,dc=my-domain,dc=com" read
-  by dn="cn=RadiusAdmin,dc=my-domain,dc=com" write
+  by dn="cn=RadiusAdmin,ou=Services,dc=my-domain,dc=com" write
   by * none
 olcAccess: to *
   by self =rwcsx
   by dn="cn=Admin,dc=my-domain,dc=com" =rcsx
-  by dn="cn=RadiusAdmin,dc=my-domain,dc=com" write
+  by dn="cn=RadiusAdmin,ou=Services,dc=my-domain,dc=com" write
   by * read

--- a/auth/openldap/config/ldif/radiusAdmin-access.ldif
+++ b/auth/openldap/config/ldif/radiusAdmin-access.ldif
@@ -3,6 +3,7 @@ changetype: modify
 replace: olcAccess
 olcAccess: to attrs=userPassword
   by anonymous auth 
+  by self =rwcsx
   by dn="cn=Admin,dc=my-domain,dc=com" read
   by dn="cn=RadiusAdmin,ou=Services,dc=my-domain,dc=com" write
   by * none

--- a/auth/openldap/docker-entrypoint.sh
+++ b/auth/openldap/docker-entrypoint.sh
@@ -67,8 +67,8 @@ lazyProcess() {
   # admin.ldif
   ldapadd -x -D "cn=Manager,dc=local,dc=doornoc,dc=net" -w ${LDAP_MANAGER_PASSWORD} -f ./admin.ldif
 
-  # access.ldif
-  ldapmodify -Q -Y EXTERNAL -H ldapi:/// -f ./access.ldif
+  # access.ldif radiusAdmin-access.ldifで上書きされるためコメントアウト
+  # ldapmodify -Q -Y EXTERNAL -H ldapi:/// -f ./access.ldif
 
   # standard-container
   ldapadd -x -D "cn=Manager,dc=local,dc=doornoc,dc=net" -w ${LDAP_MANAGER_PASSWORD} -f ./standard-container.ldif


### PR DESCRIPTION
ユーザー自身でパスワードを変更可にするための権限調整。
※ 管理用アカウントでしかすべてのユーザーのパスワードが変更できなかった。